### PR TITLE
Standard methods

### DIFF
--- a/DKQueue.h
+++ b/DKQueue.h
@@ -11,12 +11,12 @@
     NSMutableArray* array;
 }
 
-- (void)pop;
-- (void)push:(id)element;
-- (void)clear;
+-(id)dequeue;
+-(void)enqueue:(id)element;
+-(void)clear;
 
-- (id)front;
-- (BOOL)isEmpty;
-- (NSInteger)size;
+-(id)peek;
+-(BOOL)isEmpty;
+-(NSInteger)size;
 
 @end

--- a/DKQueue.m
+++ b/DKQueue.m
@@ -9,40 +9,51 @@
 
 @implementation DKQueue
 
-- (id)init
+-(id)init
 {
-    self = [super init];
-    if (self) {
+    if ( (self = [super init]) ) {
         array = [[NSMutableArray alloc] init];
     }
     
     return self;
 }
 
-- (void)pop {
-    if ([array count] > 0)
+-(id)dequeue 
+{
+    if ([array count] > 0) {
+		id object = [self peek];
         [array removeObjectAtIndex:0];
+		return object;
+	}
+	
+	return nil;
 }
 
-- (void)push:(id)element {
+-(void)enqueue:(id)element
+{
     [array addObject:element];
 }
 
-- (id)front {
+-(id)peek 
+{
     if ([array count] > 0)
         return [array objectAtIndex:0];
+	
     return nil;
 }
 
-- (NSInteger)size {
+-(NSInteger)size 
+{
     return [array count];
 }
 
-- (BOOL)isEmpty {
+-(BOOL)isEmpty 
+{
     return [array count] == 0;
 }
 
-- (void)clear {
+-(void)clear 
+{
     [array removeAllObjects];
 }
 

--- a/DKStack.h
+++ b/DKStack.h
@@ -11,12 +11,12 @@
     NSMutableArray* array;
 }
 
-- (void)pop;
-- (void)push:(id)element;
-- (void)clear;
+-(id)pop;
+-(void)push:(id)element;
+-(void)clear;
 
-- (id)top;
-- (NSInteger)size;
-- (BOOL)isEmpty;
+-(id)peek;
+-(NSInteger)size;
+-(BOOL)isEmpty;
 
 @end

--- a/DKStack.m
+++ b/DKStack.m
@@ -9,37 +9,44 @@
 
 @implementation DKStack
 
-- (id)init
+-(id)init
 {
-    self = [super init];
-    if (self) {
-        array = [[NSMutableArray alloc] init];
-    }
-    
-    return self;
+	if ( (self = [super init]) ) {
+		array = [[NSMutableArray alloc] init];
+	}
+
+	return self;
 }
 
-- (void)pop {
-    [array removeLastObject];
+-(id)pop 
+{
+	id object = [self peek];
+	[array removeLastObject];
+	return object;
 }
 
-- (void)push:(id)element {
+-(void)push:(id)element 
+{
     [array addObject:element];
 }
 
-- (id)top {
+-(id)peek 
+{
     return [array lastObject];
 }
 
-- (NSInteger)size {
+-(NSInteger)size 
+{
     return [array count];
 }
 
-- (BOOL)isEmpty {
+-(BOOL)isEmpty 
+{
     return [array count] == 0;
 }
 
-- (void)clear {
+-(void)clear 
+{
     [array removeAllObjects];
 }
 


### PR DESCRIPTION
Renamed the methods like they are usually called:

Queue: enqueue, dequeue, peek
Stack: push, pop, peek

dequeue and pop are now returning the removed element as usual.

Checked standard references from C#:
Queue: http://msdn.microsoft.com/en-us/library/system.collections.queue.aspx
Stack: http://msdn.microsoft.com/en-us/library/system.collections.stack.aspx
